### PR TITLE
Remove defunct Universal Analytics tracking

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,6 @@ description: Ferienwohnung in Podersdorf
 baseurl: "/"
 url: https://www.ferienwohnung-kaintz.at
 lang: de
-google_analytics: UA-107321-12
 markdown: kramdown
 theme: minima
 plugins:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -44,15 +44,5 @@
 
     </div>
 
-    {% if site.google_analytics %}
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      ga('create', '{{ site.google_analytics }}', 'auto');
-      ga('send', 'pageview');
-    </script>
-    {% endif %}
   </body>
 </html>


### PR DESCRIPTION
Google shut down Universal Analytics (UA) in July 2023. The `analytics.js` snippet in `_layouts/default.html` has been sending hits to a dead endpoint ever since.

**Changes:**
- Remove `google_analytics: UA-107321-12` from `_config.yml`
- Remove the UA tracking script block from `_layouts/default.html`

**Note:** If visitor tracking is still wanted, migrate to GA4 by adding a `gtag.js` snippet with a `G-XXXXXXX` property ID.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186v4XU9C2H1DUzPPJAGLK2)_