### PR TITLE
Use default layout on homepage instead of Minima's home layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 ---
-layout: home
+layout: default
 ---
 
 <img id="header" src="/assets/home.jpg">


### PR DESCRIPTION
The homepage declared `layout: home`, which is Minima's blog-oriented layout. That layout is designed to render a list of posts below the page content. This site has no posts, so the section was empty — but Minima still processes and injects it.

`fotos.html` already correctly uses `layout: default`. This change makes the homepage consistent.

**Changes:**
- `index.html`: change `layout: home` → `layout: default`

---
_Generated by [Claude Code](https://claude.ai/code/session_0186v4XU9C2H1DUzPPJAGLK2)_