### PR TITLE
Fix baseurl to empty string for root-hosted site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,7 @@ defaults:
     image: true
 email: stefan@skoegl.net
 description: Ferienwohnung in Podersdorf
-baseurl: "/"
+baseurl: ""
 url: https://www.ferienwohnung-kaintz.at
 lang: de
 google_analytics: UA-107321-12


### PR DESCRIPTION
Jekyll's `baseurl` is a path prefix for sites hosted at a subpath (e.g. `/blog` on `example.com/blog`). For a site at the domain root it must be `""`, not `"/"`.

With `baseurl: "/"`, Liquid's `relative_url` filter produces double-slash URLs such as `//assets/css/main.css`, which can cause assets to fail to load in some configurations.

**Changes:**
- `_config.yml`: `baseurl: "/"` → `baseurl: ""`

---
_Generated by [Claude Code](https://claude.ai/code/session_0186v4XU9C2H1DUzPPJAGLK2)_