### PR TITLE
Remove unloaded Hind web font from CSS font stack

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,7 +1,7 @@
 /*! HTML5 Boilerplate v5.0 | MIT License | http://h5bp.com/ */
 
 html {
-    font-family: 'Hind', Verdana, sans-serif;
+    font-family: Verdana, sans-serif;
     font-weight: 400;
     color: #333;
 }


### PR DESCRIPTION
`main.css` declared `font-family: 'Hind', Verdana, sans-serif`, but `'Hind'` is a Google Font that was never imported via `@import` or a `<link>` tag. Every visitor's browser silently fell back to Verdana.

Rather than add a web font request (extra latency, GDPR consideration), this removes the phantom entry so the declaration matches the actual behavior.

**Changes:**
- `assets/css/main.css`: `font-family: 'Hind', Verdana, sans-serif` → `font-family: Verdana, sans-serif`

---
_Generated by [Claude Code](https://claude.ai/code/session_0186v4XU9C2H1DUzPPJAGLK2)_