### PR TITLE
Fix typo: erwaschsene → erwachsene in booking form

### DIFF
--- a/_includes/anfrage.html
+++ b/_includes/anfrage.html
@@ -27,8 +27,8 @@
     </p>
 
     <p>
-      <label for="erwaschsene">Anzahl Erwachsene (ab 18 Jahren)</label>
-      <input type="text" name="erwaschsene" id="erwaschsene">
+      <label for="erwachsene">Anzahl Erwachsene (ab 18 Jahren)</label>
+      <input type="text" name="erwachsene" id="erwachsene">
     </p>
 
     <p>


### PR DESCRIPTION
The adults count field in the booking form had a misspelling in both its `name` and `id` attributes (`erwaschsene` instead of `erwachsene`). The misspelled name was what appeared in the emailed booking request received by the property owner.

**Changes:**
- `_includes/anfrage.html`: fix `erwaschsene` → `erwachsene` in `name` and `id` attributes

---
_Generated by [Claude Code](https://claude.ai/code/session_0186v4XU9C2H1DUzPPJAGLK2)_