### PR TITLE
Remove IE9 compatibility shim and X-UA-Compatible meta tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,6 @@
 <html lang="{{ site.lang | default: "en-US" }}">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
 {% seo %}
@@ -11,9 +10,6 @@
 
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
 
-    <!--[if lt IE 9]>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
-    <![endif]-->
   </head>
   <body>
 


### PR DESCRIPTION
IE9 reached end of life in January 2016 and has had 0% market share for years. Two IE-specific artefacts remained in the layout:

1. A conditional comment loading `html5shiv` for IE < 9
2. The `X-UA-Compatible: IE=edge` meta tag

Neither has any effect on any browser in use today.

**Changes:**
- `_layouts/default.html`: remove `<meta http-equiv="X-UA-Compatible">` tag
- `_layouts/default.html`: remove `html5shiv` conditional comment block

---
_Generated by [Claude Code](https://claude.ai/code/session_0186v4XU9C2H1DUzPPJAGLK2)_