### PR TITLE
Remove duplicate display: block declaration on #wrapper

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -126,7 +126,6 @@ input, select, textarea, button {
 /* color: #FFC644; */
 
 #wrapper {
-    display: block;
     max-width: 45em;
     display: inline-block;
 


### PR DESCRIPTION
In `main.css`, the `#wrapper` rule had `display: block` on one line immediately overridden by `display: inline-block` on the very next line. The first declaration was dead code.

**Changes:**
- `assets/css/main.css`: remove the redundant `display: block` line from `#wrapper`

---
_Generated by [Claude Code](https://claude.ai/code/session_0186v4XU9C2H1DUzPPJAGLK2)_