### PR TITLE
Remove unused posts and uploads collections from config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,13 +1,6 @@
 ---
 title: Ferienwohnung Kaintz
 timezone: Europe/Vienna
-collections:
-  posts:
-    title: Posts
-    output: true
-  uploads:
-    title: Uploads
-    output: true
 defaults:
 - scope:
     path: assets/img


### PR DESCRIPTION
Two Jekyll collections (`posts` and `uploads`) were defined in `_config.yml` but have no corresponding content in the repository. Jekyll scans for and processes every declared collection on every build, even empty ones.

**Changes:**
- `_config.yml`: remove the `collections` block (`posts` and `uploads`)

---
_Generated by [Claude Code](https://claude.ai/code/session_0186v4XU9C2H1DUzPPJAGLK2)_