### PR TITLE
Remove Google Tag Manager from admin panel

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1,13 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<!-- Google Tag Manager -->
-	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-	new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-	j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-	'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-	})(window,document,'script','dataLayer','GTM-WJRTJ9M');</script>
-	<!-- End Google Tag Manager -->
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>Stastic Jekyll Editor</title>
@@ -16,10 +9,6 @@
   <script type="text/javascript">window.$crisp=[];window.CRISP_WEBSITE_ID="9c68de1f-7c54-4558-835f-c8ecdab486f1";(function(){d=document;s=d.createElement("script");s.src="https://client.crisp.chat/l.js";s.async=1;d.getElementsByTagName("head")[0].appendChild(s);})();</script>
 </head>
 <body>
-	<!-- Google Tag Manager (noscript) -->
-	<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WJRTJ9M"
-	height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-	<!-- End Google Tag Manager (noscript) -->
   <span class="stastic-loader stastic-centered-message">Loading Stastic admin...</span>
   <div id="root"></div>
   <script>


### PR DESCRIPTION
GTM (`GTM-WJRTJ9M`) was present only in `admin/index.html` (the Stastic editor), not in the public site layout. This means it was tracking internal editor sessions rather than visitor traffic — the opposite of its likely intent.

**Changes:**
- `admin/index.html`: remove GTM head snippet and noscript fallback

**Note:** If visitor tracking via GTM is wanted, add the GTM snippet to `_layouts/default.html` instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186v4XU9C2H1DUzPPJAGLK2)_