### PR TITLE
Add loading="lazy" to gallery images

### DIFF
--- a/fotos.html
+++ b/fotos.html
@@ -8,7 +8,7 @@ layout: default
  {% assign image_files = site.static_files | where: "image", true %}
  {% for myimage in image_files %}
   <div>
-   <img src="{{ myimage.path }}">
+   <img src="{{ myimage.path }}" loading="lazy">
   </div>
  {% endfor %}
 </div>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@ layout: home
  {% assign image_files = site.static_files | where: "image", true %}
  {% for myimage in image_files | limit: 3 %}
   <div>
-   <img src="{{ myimage.path }}">
+   <img src="{{ myimage.path }}" loading="lazy">
   </div>
  {% endfor %}
 </div>


### PR DESCRIPTION
Both gallery pages loaded all images eagerly on page load:

- `index.html`: 3 preview images in the homepage gallery
- `fotos.html`: ~20 images totalling ~16 MB

Adding the native `loading="lazy"` attribute defers off-screen images until the user scrolls near them. No JavaScript required; supported by all modern browsers.

**Changes:**
- `index.html`: add `loading="lazy"` to gallery `<img>` tag
- `fotos.html`: add `loading="lazy"` to gallery `<img>` tag

---
_Generated by [Claude Code](https://claude.ai/code/session_0186v4XU9C2H1DUzPPJAGLK2)_