### PR TITLE
Add Impressum to footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -40,6 +40,12 @@
       </main>
 
       <footer>
+        <p>
+          <strong>Impressum</strong><br>
+          {{ site.title }}<br>
+          Podersdorf am See, Austria<br>
+          E-Mail: <a href="mailto:{{ site.email }}">{{ site.email }}</a>
+        </p>
       </footer>
 
     </div>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -168,6 +168,14 @@ nav ul li:last-child:after {
     content: "";
 }
 
+footer {
+    margin-top: 2em;
+    padding: 1em;
+    border-top: 1px solid #ddd;
+    font-size: 0.85em;
+    color: #666;
+}
+
 #podersdorf {
     display: flex;
     justify-content:space-evenly;


### PR DESCRIPTION
Austrian and German law (§ 5 ECG / § 5 TMG) requires a legal notice (Impressum) on commercial websites. The footer element in the layout was completely empty.

This adds a minimal Impressum with the site title, location, and contact email (reusing `site.email` already defined in `_config.yml`), plus basic footer styling.

**Note:** A full Impressum may require additional details depending on the business structure (e.g. UID number, trade register entry). Please review the legal requirements and extend this as needed.

**Changes:**
- `_layouts/default.html`: populate the empty `<footer>` with Impressum content
- `assets/css/main.css`: add basic footer styling

---
_Generated by [Claude Code](https://claude.ai/code/session_0186v4XU9C2H1DUzPPJAGLK2)_